### PR TITLE
Update awscli and add jq as a dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk add --update python py-pip \
+RUN apk add --no-cache python py-pip jq \
 	&& pip install --upgrade pip \
 	&& pip install awscli
 


### PR DESCRIPTION
`jq` is often used with `awscli`, so lets include this. 